### PR TITLE
Restrict image sizes to 1920px width

### DIFF
--- a/src/components/header-background.js
+++ b/src/components/header-background.js
@@ -3,6 +3,8 @@ import { graphql, useStaticQuery } from "gatsby"
 
 import BackgroundImage from "gatsby-background-image"
 
+import { updateSrcSet } from "../utils"
+
 import styles from "./header-background.module.scss"
 
 const HeaderBackground = ({ children, className }) => {
@@ -22,6 +24,7 @@ const HeaderBackground = ({ children, className }) => {
 
   // Set ImageData.
   const imageData = data.desktop.childImageSharp.fluid
+  imageData.srcSet = updateSrcSet(imageData.srcSet, 1920)
 
   return (
     <BackgroundImage

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -12,7 +12,7 @@ import Tabs from "../components/tabs"
 import Team from "../components/team"
 import SEO from "../components/seo"
 
-import { generateIdFromTitle } from "../utils"
+import { generateIdFromTitle, updateSrcSet } from "../utils"
 
 const AboutPage = ({ data, location }) => {
   const pageData = data.allMarkdownRemark.nodes[0].frontmatter
@@ -28,6 +28,9 @@ const AboutPage = ({ data, location }) => {
     pageData.herbertSimonSection.title,
     pageData.sponsorsSection.title,
   ]
+
+  const herbertImage = pageData.herbertSimonSection.photo.childImageSharp.fluid
+  herbertImage.srcSet = updateSrcSet(herbertImage.srcSet, 1920)
 
   return (
     <PageLayout
@@ -60,10 +63,7 @@ const AboutPage = ({ data, location }) => {
         </SideBySide>
       </BaseSection>
       <div id={herbertSimonSectionId}>
-        <Image
-          fluid={pageData.herbertSimonSection.photo.childImageSharp.fluid}
-          alt={pageData.herbertSimonSection.title}
-        />
+        <Image fluid={herbertImage} alt={pageData.herbertSimonSection.title} />
       </div>
       <BaseSection>
         <SideBySide title={pageData.herbertSimonSection.title} elevateTitle>

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
 
+import { updateSrcSet } from "../utils"
+
 import PageLayout from "../components/page-layout"
 import SEO from "../components/seo"
 import FeaturedTagsList from "../components/featured-tags-list"
@@ -44,13 +46,14 @@ const BlogIndex = ({ data, location }) => {
         <BaseSection>
           <Grid>
             {nodes.map(post => {
+              const postImage =
+                post.frontmatter?.featuredImage?.childImageSharp?.fluid
+              postImage.srcSet = updateSrcSet(postImage.srcSet, 750)
               return (
                 <Card
                   key={`card_${post.fields.slug}`}
                   url={post.fields.slug}
-                  image={
-                    post.frontmatter?.featuredImage?.childImageSharp?.fluid
-                  }
+                  image={postImage}
                   title={post.frontmatter.title}
                   subtitle={post.frontmatter.date}
                   content={post.frontmatter.description || post.excerpt}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 
-import { constructProjectCategoryUrl } from "../utils"
+import { constructProjectCategoryUrl, updateSrcSet } from "../utils"
 
 import PageLayout from "../components/page-layout"
 import SEO from "../components/seo"
@@ -58,13 +58,14 @@ const Home = ({ data, location }) => {
               project => project.frontmatter.category === projects.category
             )
             const projectCards = projectsByCategory.map(project => {
+              const projectImage =
+                project.frontmatter?.featuredImage?.childImageSharp?.fluid
+              projectImage.srcSet = updateSrcSet(projectImage.srcSet, 750)
               return (
                 <Card
                   key={`project_card_${project.fields.slug}`}
                   url={project.fields.slug}
-                  image={
-                    project.frontmatter.featuredImage.childImageSharp.fluid
-                  }
+                  image={projectImage}
                   title={
                     project.frontmatter.card?.title || project.frontmatter.title
                   }
@@ -103,13 +104,14 @@ const Home = ({ data, location }) => {
               numberOfColumns={2}
             >
               {news.map(post => {
+                const postImage =
+                  post.frontmatter?.featuredImage?.childImageSharp?.fluid
+                postImage.srcSet = updateSrcSet(postImage.srcSet, 750)
                 return (
                   <Card
                     key={`news_card_${post.fields.slug}`}
                     url={post.fields.slug}
-                    image={
-                      post.frontmatter?.featuredImage?.childImageSharp?.fluid
-                    }
+                    image={postImage}
                     title={post.frontmatter.title}
                     subtitle={post.frontmatter.date}
                     content={post.frontmatter.description || post.excerpt}
@@ -124,13 +126,14 @@ const Home = ({ data, location }) => {
               fixAlignment
             >
               {events.map(post => {
+                const postImage =
+                  post.frontmatter?.featuredImage?.childImageSharp?.fluid
+                postImage.srcSet = updateSrcSet(postImage.srcSet, 750)
                 return (
                   <Card
                     key={`events_card_${post.fields.slug}`}
                     url={post.fields.slug}
-                    image={
-                      post.frontmatter?.featuredImage?.childImageSharp?.fluid
-                    }
+                    image={postImage}
                     title={post.frontmatter.title}
                     subtitle={post.frontmatter.date}
                     content={post.frontmatter.description || post.excerpt}

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -7,6 +7,7 @@ import FeaturedTagsList from "../components/featured-tags-list"
 import BaseSection from "../components/sections/base"
 import CardsWithText from "../components/sections/cards-with-text"
 import Card from "../components/card"
+import { updateSrcSet } from "../utils"
 
 const ProjectsPage = ({ data, location }) => {
   const pageData = data.projectsPage.nodes[0].frontmatter
@@ -31,13 +32,14 @@ const ProjectsPage = ({ data, location }) => {
               project.frontmatter.category === projectsByCategory.category
           )
           const projectCards = projects.map(project => {
+            const projectImage =
+              project.frontmatter?.featuredImage?.childImageSharp?.fluid
+            projectImage.srcSet = updateSrcSet(projectImage.srcSet, 750)
             return (
               <Card
                 key={`project_page_card_${project.fields.slug}`}
                 url={project.fields.slug}
-                image={
-                  project.frontmatter?.featuredImage?.childImageSharp?.fluid
-                }
+                image={projectImage}
                 title={
                   project.frontmatter.card?.title || project.frontmatter.title
                 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -2,6 +2,8 @@ import React from "react"
 import { graphql } from "gatsby"
 import Image from "gatsby-image"
 
+import { updateSrcSet } from "../utils"
+
 import Authors from "../components/authors"
 import PageLayout from "../components/page-layout"
 import BaseSection from "../components/sections/base"
@@ -16,6 +18,8 @@ const BlogPostTemplate = ({ data, location }) => {
   const desktopFeaturedImage = post.frontmatter.featuredImage?.desktop?.fluid
   const seoFeaturedImage = post.frontmatter.featuredImage?.seo?.resize
   const authors = post.frontmatter.authors
+
+  desktopFeaturedImage.srcSet = updateSrcSet(desktopFeaturedImage.srcSet, 1920)
 
   const sources = [
     mobileFeaturedImage,

--- a/src/templates/subpage.js
+++ b/src/templates/subpage.js
@@ -13,7 +13,7 @@ import Tabs from "../components/tabs"
 import SEO from "../components/seo"
 import VideoList from "../components/video-list"
 
-import { generateIdFromTitle } from "../utils"
+import { generateIdFromTitle, updateSrcSet } from "../utils"
 
 const SubpageTemplate = ({ data, location }) => {
   const pageData = data.markdownRemark.frontmatter
@@ -48,6 +48,8 @@ const SubpageTemplate = ({ data, location }) => {
       </div>
     </div>
   )
+
+  desktopFeaturedImage.srcSet = updateSrcSet(desktopFeaturedImage.srcSet, 1920)
 
   const sources = [
     mobileFeaturedImage,

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,3 +20,17 @@ export function constructProjectTagUrl(tag) {
 
 export const toHTML = value =>
   remark().use(remarkHTML).processSync(value).toString()
+
+export const updateSrcSet = (srcSet, maxWidth) => {
+  if (!srcSet) return null
+  const srcSetArray = srcSet.split(",")
+  return srcSetArray
+    .reduce((filtered, src) => {
+      const [url, width] = src.split(" ")
+      if (parseInt(width) <= maxWidth) {
+        filtered.push(`${url} ${width}`)
+      }
+      return filtered
+    }, [])
+    .join(",")
+}


### PR DESCRIPTION
Hello there @longtermgov! I was browsing the website today and I noticed that the homepage header image took really long time to load. After inspecting it as well as other images on the website (cards, blog posts, projects, etc), I noticed that the browsers (and specifically Chrome on MacBooks) are using extremely high-resolution images.

This is a fix to restrict images to maximum 1920px width (full-hd). This brings down the total size of images of the homepage from `4.5MB` to just `1.3MB`! Similar improvements can be noticed in other pages with big images, like the projects page and the blog post pages.

I feel like I should have noticed this issue earlier and I should have delivered the website with this fixed. Apologies that I only noticed it now!

Let me know if you agree with the changes of this pull request and feel free to merge it into your `update-content` branch so that it can then be deployed to production afterward. I hope this pull request will create a preview link (otherwise we might need to update some settings on Netlify so that you can preview the changes, or you just merge it into the `update-content` branch and preview the changes once you make a new pull request against the `main` branch).